### PR TITLE
FIX UI5DialogHeader VerticalLayout generated without proper ID

### DIFF
--- a/Facades/Elements/UI5DialogHeader.php
+++ b/Facades/Elements/UI5DialogHeader.php
@@ -84,11 +84,9 @@ class UI5DialogHeader extends UI5Container
             $content .= $this->buildJsConstructorForChild($w, $oControllerJs) . ",\n";
         }
 
-        $id = "'{$this->getFacade()->getElement($widget)->getId()}',";
-
         return <<<JS
         
-            new sap.ui.layout.VerticalLayout({$id}{
+            new sap.ui.layout.VerticalLayout('{$this->getFacade()->getElement($widget)->getId()}',{
                 content: [
                     {$title}
                     {$content}

--- a/Facades/Elements/UI5DialogHeader.php
+++ b/Facades/Elements/UI5DialogHeader.php
@@ -83,9 +83,12 @@ class UI5DialogHeader extends UI5Container
         foreach ($widget->getWidgets() as $w) {
             $content .= $this->buildJsConstructorForChild($w, $oControllerJs) . ",\n";
         }
+
+        $id = "'{$this->getFacade()->getElement($widget)->getId()}',";
+
         return <<<JS
         
-            new sap.ui.layout.VerticalLayout({
+            new sap.ui.layout.VerticalLayout({$id}{
                 content: [
                     {$title}
                     {$content}


### PR DESCRIPTION
This should now enable all expected OnChanged behaviours for any classes that are interpreted as VerticalLayout, such as "hidden_if" for WidgetGroup.

Was this behaviour intended?