### PR TITLE
Feature/ldad 6484 expand header of an input help dialogue

### DIFF
--- a/Facades/Elements/UI5DataLookupDialog.php
+++ b/Facades/Elements/UI5DataLookupDialog.php
@@ -35,7 +35,7 @@ class UI5DataLookupDialog extends UI5Dialog
         parent::init();
         $dialog = $this->getWidget();
         if ($dialog->getHideHeader() === null) {
-            $dialog->setHideHeader(true);
+            $dialog->setHideHeader(false);
         }
         $table = $this->getWidget()->getDataWidget();
         $table->setHideCaption(true);


### PR DESCRIPTION
feat: the header inside the DataLookupDialog is now always expanded, if the hideHeader value is null.