### PR TITLE
NEW Frontend-Tracer: added basic JS Server logging

### DIFF
--- a/Facades/js/openui5.facade.js
+++ b/Facades/js/openui5.facade.js
@@ -2148,24 +2148,40 @@ const exfLauncher = {};
 				contentWidth: "90%",
 				contentHeight: "80%",
 				content: [oTable],
-				endButton: new sap.m.Button({
-					text: "Close",
-					type: "Emphasized",
-					press: function() {
-						dialog.close();
-					}
-				}),
-				beginButton: new sap.m.Button({
-					text: "Dismiss All",
-					press: function() {
-						// Clear Error List
-						capturedErrors = [];
-	
-						// Update Model 
-						oTable.getModel().setProperty("/errors", []); 
-						exfLauncher.showMessageToast("Error log cleared");
-					}
-				})
+				buttons: [
+					new sap.m.Button({
+						text: "Copy Logs",
+						press: function() {
+							const errorLogs = exfLauncher.getJsErrorLogs();
+							const errorLogsString = JSON.stringify(errorLogs, null, 2);
+
+							// Copy to clipboard
+							navigator.clipboard.writeText(errorLogsString).then(() => {
+								exfLauncher.showMessageToast("Error logs copied to clipboard!");
+							}).catch(err => {
+								console.error("Failed to copy error logs:", err);
+							});
+						}
+					}),
+					new sap.m.Button({
+						text: "Dismiss All",
+						press: function() {
+							// Clear Error List
+							capturedErrors = [];
+		
+							// Update Model 
+							oTable.getModel().setProperty("/errors", []); 
+							exfLauncher.showMessageToast("Error log cleared");
+						}
+					}),
+					new sap.m.Button({
+						text: "Close",
+						type: "Emphasized",
+						press: function() {
+							dialog.close();
+						}
+					}),
+				]
 			});
 	
 			dialog.open();

--- a/Facades/js/openui5.facade.js
+++ b/Facades/js/openui5.facade.js
@@ -2679,11 +2679,49 @@ exfLauncher.logJsError = function(args, level, message = null){
 		capturedErrors.push(logDetails);
 
 		// only show popover for error levels
+		// and send the error to the LogHub Facade
 		if (typeof exfLauncher.showErrorPopover === "function" && level === 'error') {
 			exfLauncher.showErrorPopover(sMessage);
+			exfLauncher.postJsErrorLog(logDetails);
 		}
 	}
 }
+
+exfLauncher.requestCount = 0;
+exfLauncher.MAX_REQUESTS = 60; // max requests allowed
+exfLauncher.TIME_WINDOW = 60000; // per time window in milliseconds
+
+/**
+ * Sends the JS Error to the LogHub Facade for centralized logging.
+ * @param {*} oLogDetails object containing the error log details
+ */
+exfLauncher.postJsErrorLog = function (oLogDetails) {
+
+	// basic rate limiting, to avoid spamming the logs
+	// for now, we can try at most 60 logs/minute?
+	if (exfLauncher.requestCount >= exfLauncher.MAX_REQUESTS) {
+        console.warn("Rate limit exceeded. JS Error Log not sent.");
+        return;
+    }
+
+	exfLauncher.requestCount++;
+
+	// send location/breadcrumb data with request
+	const aCrumbs = this.getShell().getModel().getProperty("/_breadcrumbs/crumbs");
+	const sCurrentTitle = this.getShell().getModel().getProperty("/_breadcrumbs/current_title");
+	let aLocations = [
+		...aCrumbs,
+		{ title: sCurrentTitle, url: oLogDetails.url }
+	];
+	oLogDetails.locations = aLocations;
+	oLogDetails.page = sCurrentTitle;
+
+	$.ajax({
+		type: 'POST',
+		url: 'api/loghub',
+		data: JSON.stringify(oLogDetails)
+	})
+};
 
 /**
  * Function that returns the current error logs
@@ -2746,6 +2784,13 @@ window.onerror = function (message, source, lineno, colno, error) {
 exfLauncher.enableJsTracing = function () {
 	window.console = window.__exfProxyInstance;
 	sessionStorage.setItem('exfJsTracingEnabled', 'true');
+	
+	// rate limiting for sending logs to server
+    if (!exfLauncher._rateLimitInterval) { // Prevent multiple intervals
+        exfLauncher._rateLimitInterval = setInterval(() => {
+            exfLauncher.requestCount = 0; 
+        }, exfLauncher.TIME_WINDOW);
+    }
 };
 
 /**
@@ -2754,6 +2799,12 @@ exfLauncher.enableJsTracing = function () {
 exfLauncher.disableJsTracing = function () {
 	window.console = window.__originalConsole;
 	sessionStorage.setItem('exfJsTracingEnabled', 'false');
+
+	// Clear the rate-limiting interval
+    if (exfLauncher._rateLimitInterval) {
+        clearInterval(exfLauncher._rateLimitInterval);
+        exfLauncher._rateLimitInterval = null; 
+    }
 };
 
 


### PR DESCRIPTION
- added basic server-side logging requests for JS errors (needs the LogHub Facade)
- added basic rate limiting features to avoid spamming the logs
- added a 'copy to clipboard' button for logs