### PR TITLE
Feature/devman 1850 tour guide page to dialog connection

### DIFF
--- a/Facades/Elements/Traits/UI5DataElementTrait.php
+++ b/Facades/Elements/Traits/UI5DataElementTrait.php
@@ -327,6 +327,9 @@ JS;
                 $js = $sidebarEl->buildJsConstructorForDynamicSideContent($js, $oControllerJs);
             }
         }
+        
+        $controller->addOnInitScript($this->buildJsWindowTourContent());
+        
         return $js;
     }
 

--- a/Facades/Elements/Traits/UI5TourGuideTrait.php
+++ b/Facades/Elements/Traits/UI5TourGuideTrait.php
@@ -62,9 +62,25 @@ trait UI5TourGuideTrait {
                     }
                 })
 JS;
+            
+            if ($controller !== null) {
+                if ($tour->getId() !== null)
+                {
+                    $tourId = $this->escapeString($tour->getId());
 
-            if ($controller !== null && $tour->getAutorun()) {
-                $this->addTourOnShowView($controller, $startTourJs);
+                    $js = <<<JS
+                
+                        const tourIntent = window.exfTourContext.consumePendingTour({$tourId});
+                        if (tourIntent) {
+                            {$startTourJs}
+                        } 
+JS;
+                    $this->addTourOnShowView($controller, $js);
+                }
+
+                if ($tour->getAutorun()) {
+                    $this->addTourOnShowView($controller, $startTourJs);
+                }
             }
         }
 
@@ -82,6 +98,54 @@ JS;
                     ]
                 })
             }),
+JS;
+    }
+
+    /**
+     * Builds JS to manage pending tour intents in the global window context. 
+     * This allows tours to be triggered from other views and then automatically started when the user navigates to the relevant view or a dialog.
+     * 
+     * @return string
+     */
+    public function buildJsWindowTourContent(): string
+    {
+        return <<<JS
+        
+            window.exfTourContext = window.exfTourContext || (function () {
+                let pendingTour = null;
+            
+                return {
+                    setPendingTour(payload) {
+                        pendingTour = {
+                            ...payload,
+                            createdAt: Date.now()
+                        };
+                    },
+            
+                    consumePendingTour(targetTourId) {
+                        if (!pendingTour) {
+                            return null;
+                        }
+                        
+                        const tooOld = (Date.now() - pendingTour.createdAt) > 60000;
+                        const matchesTour = pendingTour.targetTourId === targetTourId;
+                        
+                        if (tooOld || !matchesTour) {
+                            pendingTour = null;
+                            return null;
+                        }
+                    
+                        const result = pendingTour;
+                        pendingTour = null;
+                        return result;
+                    },
+                
+                    clear() {
+                        pendingTour = null;
+                    }
+              };
+            })();
+
 JS;
     }
 

--- a/Facades/Elements/UI5AbstractElement.php
+++ b/Facades/Elements/UI5AbstractElement.php
@@ -59,6 +59,7 @@ abstract class UI5AbstractElement extends AbstractJqueryElement
         
         // Register tour steps if there are any
         $widget = $this->getWidget();
+        //TODO: currently if we are in a dialog, one step from the calling page will be also registered. This should be fixed.
         foreach ($widget->getTourSteps() as $tourStep) {
             $this->getFacade()->getTourDriver($widget)->registerWaypointStep($tourStep);
         }


### PR DESCRIPTION
Feature: added pending tour consumption logic. pending tours will be executed on view load automatically.
With it, a tour, that will continue inside an opened dialog can be configurated.

Related PR: https://github.com/ExFace/Core/pull/769