### PR TITLE
Feature/devman 1849 url param autostart

### DIFF
--- a/Facades/Elements/Traits/UI5TourGuideTrait.php
+++ b/Facades/Elements/Traits/UI5TourGuideTrait.php
@@ -67,7 +67,10 @@ JS;
                 if ($tour->getId() !== null)
                 {
                     $tourId = $this->escapeString($tour->getId());
-
+                    
+                    // IF the tour is pending (e.g. triggered from another view)
+                    // or the URL contains a query parameter to trigger the tour,
+                    // starts it automatically when the view is shown
                     $js = <<<JS
                         const tourIdInURL = new URLSearchParams(window.location.search).get('tour') === {$tourId}
                         const tourIntent = window.exfTourContext.consumePendingTour({$tourId})

--- a/Facades/Elements/Traits/UI5TourGuideTrait.php
+++ b/Facades/Elements/Traits/UI5TourGuideTrait.php
@@ -69,9 +69,9 @@ JS;
                     $tourId = $this->escapeString($tour->getId());
 
                     $js = <<<JS
-                
-                        const tourIntent = window.exfTourContext.consumePendingTour({$tourId});
-                        if (tourIntent) {
+                        const tourIdInURL = new URLSearchParams(window.location.search).get('tour') === {$tourId}
+                        const tourIntent = window.exfTourContext.consumePendingTour({$tourId})
+                        if (tourIntent || tourIdInURL) {
                             {$startTourJs}
                         } 
 JS;
@@ -130,8 +130,12 @@ JS;
                         const tooOld = (Date.now() - pendingTour.createdAt) > 60000;
                         const matchesTour = pendingTour.targetTourId === targetTourId;
                         
-                        if (tooOld || !matchesTour) {
+                        if (tooOld) {
                             pendingTour = null;
+                            return null;
+                        }
+
+                        if (!matchesTour) {
                             return null;
                         }
                     

--- a/Facades/Elements/Traits/UI5TourGuideTrait.php
+++ b/Facades/Elements/Traits/UI5TourGuideTrait.php
@@ -70,11 +70,23 @@ JS;
                     
                     // IF the tour is pending (e.g. triggered from another view)
                     // or the URL contains a query parameter to trigger the tour,
-                    // starts it automatically when the view is shown
+                    // starts it automatically when the view is shown.
+                    //
+                    // tour query parameter is removed after consumption to prevent
+                    // unwanted retriggering on back/forward navigation.
                     $js = <<<JS
-                        const tourIdInURL = new URLSearchParams(window.location.search).get('tour') === {$tourId}
+                        const tourUrl = new URL(window.location.href);
+                        const tourIdInURL = tourUrl.searchParams.get('tour') === {$tourId}
                         const tourIntent = window.exfTourContext.consumePendingTour({$tourId})
                         if (tourIntent || tourIdInURL) {
+                            if (tourIdInURL) {
+                                tourUrl.searchParams.delete('tour')
+                                window.history.replaceState(
+                                    window.history.state, document.title, 
+                                    tourUrl.pathname + tourUrl.search + tourUrl.hash
+                                );
+                            }
+
                             {$startTourJs}
                         } 
 JS;


### PR DESCRIPTION
NEW: Tour URL query parameter is removed after consumption to prevent unwanted retriggering on back/forward navigation.