### PR TITLE
NEW: WidgetSetups can now save/load header filters

### DIFF
--- a/Facades/Elements/UI5DataConfigurator.php
+++ b/Facades/Elements/UI5DataConfigurator.php
@@ -264,13 +264,167 @@ function(){
                 "columns": columns,
                 "sortables": sortables,
                 "searchables": searchables,
-                "sorters": [{$this->buildJsonModelForInitialSorters()}]
+                "sorters": [{$this->buildJsonModelForInitialSorters()}],
+                "header_filters": []
             }
             oModel.setData(data);
             return oModel;        
         }()
 JS;
     }
+    
+    /**
+     * Returns JavaScript code to reset all visible, non-optional filters to empty values.
+     * This is used before applying a new set of filter values, ensuring all filters are cleared first.
+     *
+     * @return string JavaScript function to clear visible, non-optional filters
+     */
+    public function buildJsResetVisibleFilters() : string
+    {
+        $resetJs = '';
+        foreach ($this->getWidget()->getFilters() as $filter) {
+            $filterElement = $this->getFacade()->getElement($filter);
+            
+            // only reset visible, non-optional filters
+            if (! $filterElement->isVisible() || $filter->getVisibility() === EXF_WIDGET_VISIBILITY_OPTIONAL) {
+                continue;
+            }
+
+            // Range filters expand into two inner from/to filter elements; regular filters produce one
+            $elementsToProcess = $filterElement instanceof UI5RangeFilter
+                ? $filterElement->getInnerFilterElements()
+                : [$filterElement];
+
+            foreach ($elementsToProcess as $el) {
+                $resetter = $el->buildJsResetter();
+                $resetJs .= <<<JS
+try {
+    $resetter;
+} catch (error) {
+    console.warn("Could not reset filter value: ", error);
+}
+JS;
+            }
+        }
+
+        return <<<JS
+function() {
+    // reset all visible filters 
+    {$resetJs}
+}
+JS;
+    }
+
+    /**
+     * Returns a JS function expression that, when called with an array of condition objects and values, sets the provided filter values.
+     *
+     * Each item in the array must be a condition object. Two formats are supported: Regular conditions (filters with a simple attribute alias)
+     * and nested condition groups (filters with a `condition_group` UXON). For normal filters, the `expression` and `comparator` properties 
+     * are compared to determine which filter to set. For nested groups, the whole group is compared.
+     *
+     * Only visible, non-optional filters are considered. After applying all values, the configured widget
+     * is refreshed to load data with the new filter state.
+     * 
+     * Example usage:
+     * 
+     * var aVals = [
+     *   {expression: "STATUS", comparator: "=", value: "1"},
+     *   {group: {nested: true, group: [{expression: "A"}, {expression: "B"}]}, value: "foo"}
+     * ];
+     * var fnSet = {$this->buildJsVisibleFilterValueSetter()};
+     * fnSet(aVals);
+     *
+     * @return string JS function expression
+     */
+    public function buildJsVisibleFilterValueSetter() : string
+    {
+        $conditions = '';
+        $busyControlIds = [];
+        $refreshWidget = $this->getFacade()->getElement($this->getWidget()->getWidgetConfigured())->buildJsRefresh();
+        
+        foreach ($this->getWidget()->getFilters() as $filter) {
+            
+            /** @var \exface\Core\Widgets\Filter $filter */
+            $filterElement = $this->getFacade()->getElement($filter);
+            $alias = $filter->getAttributeAlias();
+                
+            // only consider visible filters
+            if (! $filterElement->isVisible() || $filter->getVisibility() === EXF_WIDGET_VISIBILITY_OPTIONAL) {
+                continue;
+            }
+
+            // Range filters expand into two inner from/to filter elements; regular filters produce one
+            $elementsToProcess = $filterElement instanceof UI5RangeFilter
+                ? $filterElement->getInnerFilterElements()
+                : [$filterElement];
+
+            // build JS if/else conditions to set the data of each visible filter element using its ValueSetter
+            foreach ($elementsToProcess as $el) {
+                // get the inner input element ID for the busy check (those are the ones that actaully are set busy)
+                $inputEl = $el instanceof UI5Filter ? $this->getFacade()->getElement($el->getWidget()->getInputWidget()) : $el;
+                $busyControlIds[] = $inputEl->getId();
+                $setter = $el->buildJsValueSetter('mVal');
+                $comparatorGetter = $el->buildJsComparatorGetter();
+                $prefix = $conditions === '' ? 'if' : ' else if';
+                
+                if ($filter->hasCustomConditionGroup()) {
+                    // For filters with custom (nested) condition groups, compare by group structure instead of alias
+                    $expectedGroupUxon = $filter->getCustomConditionGroup()->exportUxonObject()->toJson();
+                    $matchCondition = "oCondition.nested && exfTools.data.compareJSONObjects(oCondition.group, {$expectedGroupUxon}, ['value'])";
+                    $errorMessage = 'Error setting filter value for nested condition group from widget setup: ';
+                } else {
+                    // otherwise chekc for alias and comparator
+                    $matchCondition = "oCondition.expression === {$this->escapeString($alias)} && oCondition.comparator === {$comparatorGetter}";
+                    $errorMessage = "Error setting filter value for filter with alias {$alias} from widget setup: ";
+                }
+
+                $conditions .= <<<JS
+{$prefix} ({$matchCondition}) {
+    try {
+        {$setter};
+    } catch (error) {
+        console.error("{$errorMessage}", error);
+    }
+}
+JS;
+            }
+        }
+        $busyControlIdsJs = json_encode(array_values(array_unique($busyControlIds)));
+
+        return <<<JS
+function(aValues) {
+
+    // set new values
+    aValues.forEach(function(oCondition) {
+        var mVal = oCondition.value;
+        {$conditions}
+    });
+
+    // wait until all updated filter controls are not busy anymore
+    var aWaitControlIds = {$busyControlIdsJs} || [];
+    var iWaitStepMs = 50;
+
+    var fnHasBusyControls = function() {
+        return aWaitControlIds.some(function(sId) {
+            var oControl = sap.ui.getCore().byId(sId);
+            return oControl && typeof oControl.getBusy === 'function' && oControl.getBusy() === true;
+        });
+    };
+
+    var fnRefreshWhenReady = function() {
+        if (!fnHasBusyControls()) {
+            // refresh the widget after values have been set to request data with new filters
+            {$refreshWidget}
+            return;
+        }
+        setTimeout(fnRefreshWhenReady, iWaitStepMs);
+    };
+
+    setTimeout(fnRefreshWhenReady, 0);
+}
+JS;
+    }
+
                
     /**
      * 
@@ -924,6 +1078,26 @@ JS;
 
 function(){
     var oData = {$this->buildJsDataGetterViaTrait($action)};
+
+    if (oData.filters) {
+        // save current state of filters in model (to be used in widget setups)
+        try {
+            var oDialog = sap.ui.getCore().byId('{$this->getId()}');
+            var oCurrentModel = oDialog.getModel('{$this->getModelNameForConfig()}');
+            oCurrentModel.setProperty('/header_filters', oData.filters);
+
+            // Remove hidden property from each condition in the filter before sending to server
+            // (this is just needed for the widget setups)
+            if (oData.filters.conditions) {
+                oData.filters.conditions.forEach(function(oCondition) {
+                    delete oCondition.hidden;
+                });
+            }
+        } catch (error) {
+            console.error("Error saving filters to model: ", error);
+        }
+    }
+
     var aFilters = sap.ui.getCore().byId('{$this->getIdOfSearchPanel()}').getFilterItems();
     var i = 0;
     var fnNot = function(oCondition) {

--- a/Facades/Elements/UI5DataConfigurator.php
+++ b/Facades/Elements/UI5DataConfigurator.php
@@ -28,6 +28,7 @@ class UI5DataConfigurator extends UI5Tabs
     use JqueryDataConfiguratorTrait {
         buildJsDataGetter as buildJsDataGetterViaTrait;
         buildJsResetter as buildJsResetterViaTrait;
+        buildJsFilterGetter as buildJsFilterGetterViaTrait;
     }
     
     const EVENT_BUTTON_OK = 'ok';
@@ -1082,17 +1083,10 @@ function(){
     if (oData.filters) {
         // save current state of filters in model (to be used in widget setups)
         try {
+            let oFilters = {$this->buildJsFilterGetterViaTrait()};
             var oDialog = sap.ui.getCore().byId('{$this->getId()}');
             var oCurrentModel = oDialog.getModel('{$this->getModelNameForConfig()}');
-            oCurrentModel.setProperty('/header_filters', oData.filters);
-
-            // Remove hidden property from each condition in the filter before sending to server
-            // (this is just needed for the widget setups)
-            if (oData.filters.conditions) {
-                oData.filters.conditions.forEach(function(oCondition) {
-                    delete oCondition.hidden;
-                });
-            }
+            oCurrentModel.setProperty('/header_filters', oFilters);
         } catch (error) {
             console.error("Error saving filters to model: ", error);
         }

--- a/Facades/Elements/UI5DataTable.php
+++ b/Facades/Elements/UI5DataTable.php
@@ -471,6 +471,8 @@ JS;
                         new sap.ui.unified.Menu()
                     ]
                 })
+                .data('fnSetVisibleHeaderFilters', {$this->getConfiguratorElement()->buildJsVisibleFilterValueSetter()})
+                .data('fnResetVisibleHeaderFilters', {$this->getConfiguratorElement()->buildJsResetVisibleFilters()})
                 {$this->buildJsClickHandlers('oController')}
                 {$this->buildJsPseudoEventHandlers()}
                 ,
@@ -786,6 +788,8 @@ JS;
                 ],
                 rows: "{/rows}"
         	}).addStyleClass('rowAlternate-'+{$striped})
+            .data('fnSetVisibleHeaderFilters', {$this->getConfiguratorElement()->buildJsVisibleFilterValueSetter()})
+            .data('fnResetVisibleHeaderFilters', {$this->getConfiguratorElement()->buildJsResetVisibleFilters()})
             {$this->buildJsClickHandlers('oController')}
             {$this->buildJsPseudoEventHandlers()}
 

--- a/Facades/Elements/UI5RangeFilter.php
+++ b/Facades/Elements/UI5RangeFilter.php
@@ -42,4 +42,23 @@ class UI5RangeFilter extends UI5Filter
         
         return $this;
     }
+
+    /**
+     * Returns the two inner filter elements (from/to) of this range filter.
+     * Used by UI5DataConfigurator::buildJsFilterValueSetter to generate separate
+     * setter conditions for the from and to comparators.
+     *
+     * @return \exface\UI5Facade\Facades\Elements\UI5Filter[]
+     */
+    public function getInnerFilterElements() : array
+    {
+        $elements = [];
+        foreach ($this->getWidgetInlineGroup()->getWidgets() as $widget) {
+            $element = $this->getFacade()->getElement($widget);
+            if ($element instanceof UI5Filter) {
+                $elements[] = $element;
+            }
+        }
+        return $elements;
+    }
 }

--- a/Facades/js/exfSetupManager.js
+++ b/Facades/js/exfSetupManager.js
@@ -511,7 +511,8 @@
             let oSetupJson = {
                 columns: [],
                 advanced_search: [],
-                sorters: []
+                sorters: [],
+                header_filters: []
             };
 
             // get the current states
@@ -521,6 +522,7 @@
             let oP13nModel = oDialog.getModel(sP13nModelName); 
             let aColumns = oP13nModel.getProperty('/columns');
             let aSorters = oP13nModel.getProperty('/sorters');
+            let aHeaderFilters = oP13nModel.getProperty('/header_filters');
             let aFilters = sap.ui.getCore().byId(sP13nSearchPanelId).getFilterItems();
 
             // save current column config
@@ -579,6 +581,45 @@
                         exclude: oFilter.mProperties.exclude
                     });
                 });
+            }
+
+            // save header filters (these are saved in the model by the UI5DataConfigurator in the DataGetter)
+            if (aHeaderFilters !== undefined && Object.keys(aHeaderFilters).length > 0) {
+                let aConditions = [];
+
+                // collect top-level conditions
+                if (aHeaderFilters.conditions) {
+                    aHeaderFilters.conditions.forEach(function(oCondition) {
+                        if (oCondition.hidden === false){
+                            // skip hidden filters
+                            aConditions.push({
+                                expression: oCondition.expression,
+                                comparator: oCondition.comparator,
+                                value: oCondition.value
+                            });
+                        }
+                        
+                    });
+                }
+
+                // collect conditions from nested groups (just put the entire group)
+                if (aHeaderFilters.nested_groups) {
+                    aHeaderFilters.nested_groups.forEach(function(oGroup) {
+                        let mVal = null;
+                        if (oGroup.conditions) {
+                            mVal = oGroup.conditions[0].value; // just take the value of the first condition
+                        }
+                        aConditions.push({
+                            nested: true,
+                            group: oGroup,
+                            value: mVal
+                        });
+                    });
+                }
+
+                if (aConditions.length > 0) {
+                    oSetupJson.header_filters = aConditions;
+                }
             }
 
             return oSetupJson;
@@ -760,6 +801,36 @@
                     });
                     oDialog.addFilterItem(oFilterItem);
                 });
+            }
+
+            // reset header filters when switching setups
+            let fnResetHeaderFilters = sap.ui.getCore().byId(sDataTableId).data('fnResetVisibleHeaderFilters');
+            if (fnResetHeaderFilters) {
+                fnResetHeaderFilters();
+            }
+            
+            if (oSetupUxon.header_filters !== undefined) {
+                // HEADER FILTER SETUP (see Ui5DataConfigurator->buildJsFilterValueSetter)
+
+                // setter function is stored in DataTable 
+                // (otherwise it leads to namespace issues when tyring to pass it via the CallWidgetFunction, because we save the setup calling from a showDialogue action)
+                let fnSetHeaderFilters = sap.ui.getCore().byId(sDataTableId).data('fnSetVisibleHeaderFilters');
+                if (fnSetHeaderFilters) {
+                    // values to be set
+                    let aValuesJs = oSetupUxon.header_filters;
+                    if (Array.isArray(aValuesJs)) {
+                        aValuesJs = aValuesJs.filter(function(oCondition) {
+                            // Skip conditions with empty or null values
+                            return oCondition && oCondition.value !== '' && oCondition.value !== null && oCondition.value !== undefined;
+                        });
+                    }
+
+                    try {
+                        fnSetHeaderFilters(aValuesJs);
+                    } catch (e) {
+                        console.error("An error occurred while setting header filters:", e);
+                    }
+                }
             }
         }
     }

--- a/Facades/js/exfSetupManager.js
+++ b/Facades/js/exfSetupManager.js
@@ -598,22 +598,25 @@
                                 value: oCondition.value
                             });
                         }
-                        
                     });
                 }
 
                 // collect conditions from nested groups (just put the entire group)
                 if (aHeaderFilters.nested_groups) {
                     aHeaderFilters.nested_groups.forEach(function(oGroup) {
-                        let mVal = null;
-                        if (oGroup.conditions) {
-                            mVal = oGroup.conditions[0].value; // just take the value of the first condition
+                        // skip hidden filters
+                        if (oGroup.hidden === false){
+                            let mVal = null;
+                            if (oGroup.conditions) {
+                                mVal = oGroup.conditions[0].value; // just take the value of the first condition
+                            }
+                            delete oGroup.hidden; // otherwise comparing the uxon to apply the filters doesnt work
+                            aConditions.push({
+                                nested: true,
+                                group: oGroup,
+                                value: mVal
+                            });
                         }
-                        aConditions.push({
-                            nested: true,
-                            group: oGroup,
-                            value: mVal
-                        });
                     });
                 }
 


### PR DESCRIPTION
**Facades/Elements/UI5DataConfigurator.php:** 
- the current state of the header filters is now saved to the Configurator Model during the DataGetter. This is now done using a seperate JqueryConfiguratorTrait->buildJsFilterGetter() method to avoid server-side issues, and not change the request data 
- new Methods buildJsVisibleFilterValueSetter() and buildJsResetVisibleFilters() that can set/reset the filter values using the widgets DataSetter/Resetter. 

**Facades/Elements/UI5DataTable.php:**
- attached the methods to set/reset data for the tables header filters to the table objects

**Facades/js/exfSetupManager.js:**
- now saves all non-hidden filters from the Configurator Model to the setup when saving a new one
- resets and sets stored filter values when applying a widget setup using the functions attached to the table object

Needs Core-PR: https://github.com/ExFace/Core/pull/772


