### PR TITLE
NEW WidgetGroup/Panel: improved layout for buttons

### DIFF
--- a/Facades/Elements/UI5Panel.php
+++ b/Facades/Elements/UI5Panel.php
@@ -517,6 +517,15 @@ JS;
                 $fields = $element->buildJsConstructor();
                 $element->setRenderCaptionAsLabel(true);
             } else {
+                if ($element instanceof UI5Button){
+                    // for Buttons, add a hidden/empty label, to make them align with the rest of the layout
+                    // and not strech tthe entire width of the form element.
+                    $label = "label: new sap.m.Label({
+                        text: '',
+                        visible: false
+                    }),";
+                }
+                
                 $fields= $element->buildJsConstructor();
             }
             $js .= $js !== '' ? ",\n" : '';


### PR DESCRIPTION
when placing buttons in widgetgroups, they used to span the entire width of the group. By adding a hidden label element, they look more uniform with the rest of the content 