### PR TITLE
FIX Text: missing space between text and label

### DIFF
--- a/Facades/Elements/UI5Value.php
+++ b/Facades/Elements/UI5Value.php
@@ -169,7 +169,7 @@ JS;
             return '';
         }        
         if ($this->getRenderCaptionAsLayout() === true) {
-            $caption .= ':';
+            $caption .= ":\u{00A0}";
         }
         $caption = $this->escapeJsTextValue($caption);
         $labelAppearance = '';


### PR DESCRIPTION
inline text widgets need a non breaking space between label and text 