### PR TITLE
NEW Navtiles: added search and tabbar 

### DIFF
--- a/Facades/Elements/UI5NavTiles.php
+++ b/Facades/Elements/UI5NavTiles.php
@@ -110,7 +110,20 @@ JS;
                     shrinkable: false
                 }))
             ]
-        }).addStyleClass('navTilesToolbar'),
+        }).addStyleClass('navTilesToolbar')
+        .addEventDelegate({
+            onAfterRendering: function() {
+                // after rendering, auto-focus the search field 
+                // (so the user can start typing immediately)
+                var oToolbar = sap.ui.getCore().byId("{$this->getId()}_navbox");
+                var oSearch = oToolbar.getContent().find(function(oCtrl) {
+                    return oCtrl.isA("sap.m.SearchField");
+                });
+                if (oSearch) {
+                    setTimeout(function() { oSearch.focus(); }, 0);
+                }
+            }
+        }),
 
 JS;
     }

--- a/Facades/Elements/UI5NavTiles.php
+++ b/Facades/Elements/UI5NavTiles.php
@@ -71,89 +71,44 @@ JS;
      */
     protected function buildJsIconTabBar() : string
     {
-        $this->getController()->addOnEventScript($this, 'TabSelect', <<<JS
-
-            // Get the selected key
-            var sKey = oEvent.getParameter("key");
-
-             // Find the corresponding panel that matches the key dynamically
-            var oView = this.getView();
-            var oPanel = sap.ui.getCore().byId(sKey);
-            if (oPanel && oPanel.getDomRef()) {
-                oPanel.getDomRef().scrollIntoView({ behavior: "smooth" });
-            }
-JS);
-
-        $this->getController()->addOnEventScript($this, 'FilterTiles', <<<JS
-            
-            // Get search query
-            const sQuery = oEvent.getParameter("newValue");
-        
-            // Retrieve all panel IDs and slice to remove the first two IDs
-            var aPanelIds = this.getView().findAggregatedObjects(true, function(oControl) {
-            return oControl.isA("sap.m.Panel");
-            }).map(function(oPanel) {
-            return oPanel.getId();
-            }).slice(2);
-        
-            // Looping through each panel and filter based on tiles header names and content text
-            aPanelIds.forEach(function(sPanelId) {
-                // Retrieving the panel control based on the ID
-                var oPanel = sap.ui.getCore().byId(sPanelId)
-                var aTiles = oPanel.getContent();
-                var bAnyTileVisible = false;
-        
-                aTiles.forEach(function(oTile) {
-                    var sTileHeader = oTile.getHeader();
-                    var aTileContent = oTile.getTileContent();
-                    var sContentText = "";
-
-                    // Loop through the TileContent array to retrieve text
-                    aTileContent.forEach(function(oTileContent) {
-                           var oContent = oTileContent.getContent();
-                           if (oContent && oContent.isA("sap.m.FeedContent")) {
-                               sContentText = oContent._oContentText.mProperties.text;
-                           }
-                       });
-                    
-                       // If the header text or content text contains the search query, set the tile to visible
-                       var bVisible = !!(sTileHeader.toLowerCase().indexOf(sQuery.toLowerCase()) !== -1 || (sContentText && sContentText.toLowerCase().indexOf(sQuery.toLowerCase()) !== -1));
-                       
-                       // If at least one tile is visible, set the panel to visible
-                       if (bVisible) {
-                           bAnyTileVisible = true;
-                       }
-                       // Set visibility of the tile
-                       oTile.setVisible(bVisible);
-                });
-                oPanel.setVisible(bAnyTileVisible);
-            }.bind(this));
-            
-    JS);
-
         return <<<JS
 
-        new sap.m.FlexBox("{$this->getId()}_navbox", {
-            backgroundDesign: "Solid",
-            items: [
+        new sap.m.OverflowToolbar("{$this->getId()}_navbox", {
+            design: "Solid",
+            content: [
                 new sap.m.IconTabHeader("{$this->getId()}_iconTabHeader", {
                     mode: "Inline",
-                    select: {$this->getController()->buildJsEventHandler($this, 'TabSelect', true)},
+                    select: function(oEvent) {
+                        // Get the selected key
+                        var sKey = oEvent.getParameter("key");
+
+                        // Find the corresponding panel that matches the key and scroll it into view
+                        var oPanel = sap.ui.getCore().byId(sKey);
+                        if (oPanel && oPanel.getDomRef()) {
+                            oPanel.getDomRef().scrollIntoView({ behavior: "smooth" , block: "start" });
+                        }
+                    },
                     items: [
                         {$this->buildJsIconTabBarItems()}
                     ]
-                }).addStyleClass('customHeader').setLayoutData(new sap.m.FlexItemData({
-            growFactor: 1,
-            shrinkFactor: 1
-        })),
+                })
+                .addStyleClass('customHeader exf-navtiles-tab-header').setLayoutData(new sap.m.OverflowToolbarLayoutData({
+                    priority: sap.m.OverflowToolbarPriority.NeverOverflow,
+                    shrinkable: true,
+                    minWidth: "14rem"
+                })),
+                new sap.m.ToolbarSpacer(),
                 new sap.m.SearchField({
-                    placeholder: "Search...",
-                    liveChange: {$this->getController()->buildJsEventHandler($this, 'FilterTiles', true)},
-                }).setLayoutData(new sap.m.FlexItemData({
-            growFactor: 0
-        }))
+                    placeholder: "{$this->getWorkbench()->getCoreApp()->getTranslator()->translate('ACTION.SHOWLOOKUPDIALOG.NAME')}", 
+                    liveChange: {$this->buildJsSearchTilesFunction()}
+                })
+                .addStyleClass('exf-navtiles-search')
+                .setLayoutData(new sap.m.OverflowToolbarLayoutData({
+                    priority: sap.m.OverflowToolbarPriority.NeverOverflow,
+                    shrinkable: false
+                }))
             ]
-        }).addStyleClass('responsiveFlexbox'),
+        }).addStyleClass('navTilesToolbar'),
 
 JS;
     }
@@ -202,5 +157,104 @@ JS;
     public function buildCssElementClass()
     {
         return 'exf-navtiles' . ($this->isFillingContainer() ? ' exf-panel-no-border' : '');
+    }
+
+    /**
+     * JS function to filter tiles at runtime, by toggling them in-/visible
+     * @return string
+     */
+    protected function buildJsSearchTilesFunction(){
+        return <<<JS
+        function(oEvent) {
+            // normalize search query
+            var sQuery = (oEvent.getParameter("newValue") || "").trim().toLowerCase();
+
+            // get root control
+            var oRootControl = sap.ui.getCore().byId("{$this->getId()}") || oEvent.getSource();
+            if (!oRootControl) {
+                return;
+            }
+
+            // get all panels that contain tiles 
+            var aPanels = oRootControl.findAggregatedObjects(true, function(oControl) {
+                return oControl.isA("sap.m.Panel");
+            }).filter(function(oPanel) {
+                // Exclude panels that were hidden from the beginning. 
+                // for example when hiding the first panel (overview), we do not want to search it and suddenly set it visible here
+                var bInitiallyVisible;
+                if (oPanel.data) {
+                    bInitiallyVisible = oPanel.data("_exfInitialVisible");
+                    if (typeof bInitiallyVisible !== "boolean") {
+                        bInitiallyVisible = oPanel.getVisible() !== false;
+                        oPanel.data("_exfInitialVisible", bInitiallyVisible);
+                    }
+                } else {
+                    bInitiallyVisible = oPanel.getVisible() !== false;
+                }
+
+                if (bInitiallyVisible === false) {
+                    return false;
+                }
+
+                // Keep only tile group panels (contain at least one GenericTile).
+                var aTiles = oPanel.getContent();
+                return Array.isArray(aTiles) && aTiles.some(function(oTile) {
+                    return oTile && oTile.isA && oTile.isA("sap.m.GenericTile");
+                });
+            });
+
+            aPanels.forEach(function(oPanel) {
+
+                var aTiles = oPanel.getContent() || [];
+                var bAnyTileVisible = false;
+
+                aTiles.forEach(function(oTile) {
+                    if (!oTile || !oTile.isA || !oTile.isA("sap.m.GenericTile")) {
+                        return;
+                    }
+
+                    // keep searchable text in data attribute to avoid rebuilding on every key stroke.
+                    var sSearchText = oTile.data("_exfSearchText");
+                    if (!sSearchText) {
+                        var aParts = [];
+                        if (oTile.getHeader) {
+                            aParts.push(oTile.getHeader() || "");
+                        }
+                        if (oTile.getSubheader) {
+                            aParts.push(oTile.getSubheader() || "");
+                        }
+
+                        (oTile.getTileContent() || []).forEach(function(oTileContent) {
+                            var oContent = oTileContent && oTileContent.getContent ? oTileContent.getContent() : null;
+                            if (!oContent) {
+                                return;
+                            }
+                            if (oContent.getText) {
+                                aParts.push(oContent.getText() || "");
+                            }
+                            if (oContent.getValue) {
+                                aParts.push(oContent.getValue() || "");
+                            }
+                        });
+
+                        sSearchText = aParts.join(" ").toLowerCase();
+                        if (oTile.data) {
+                            oTile.data("_exfSearchText", sSearchText);
+                        }
+                    }
+
+                    var bVisible = (sQuery === "") || (sSearchText.indexOf(sQuery) !== -1);
+                    if (bVisible) {
+                        bAnyTileVisible = true;
+                    }
+                    // Set visibility of the tile
+                    oTile.setVisible(bVisible);
+                });
+
+                // hide entire panel if no tile visible
+                oPanel.setVisible(bAnyTileVisible);
+            });
+    }
+JS;
     }
 }

--- a/Facades/Elements/UI5NavTiles.php
+++ b/Facades/Elements/UI5NavTiles.php
@@ -71,6 +71,8 @@ JS;
      */
     protected function buildJsIconTabBar() : string
     {
+        // note sah: switched from flexbox to overflow toolbar because of layout issues
+        // the page was otherwise rendering content/headings underneath the tabbar, and the overflow didnt work correctly
         return <<<JS
 
         new sap.m.OverflowToolbar("{$this->getId()}_navbox", {
@@ -93,7 +95,7 @@ JS;
                     ]
                 })
                 .addStyleClass('customHeader exf-navtiles-tab-header').setLayoutData(new sap.m.OverflowToolbarLayoutData({
-                    priority: sap.m.OverflowToolbarPriority.NeverOverflow,
+                    priority: sap.m.OverflowToolbarPriority.Low,
                     shrinkable: true,
                     minWidth: "14rem"
                 })),

--- a/Facades/Elements/UI5NavTiles.php
+++ b/Facades/Elements/UI5NavTiles.php
@@ -140,7 +140,7 @@ JS;
 
                 // hide the first tile group (the overview), but only if the depth is not 1,
                 // otherwise we get issues with landing pages etc, as they dont display any data then
-                if ($this->getWidget()->getDepth() === 1) {
+                if ($this->getWidget()->getDepth() === 1 || count($this->getWidget()->getTiles()) === 1) {
                     $tileGroup->setHidden(false);
                     continue;
                 }

--- a/Facades/Elements/UI5NavTiles.php
+++ b/Facades/Elements/UI5NavTiles.php
@@ -122,7 +122,15 @@ JS;
         $js = '';
         foreach ($this->getWidget()->getTiles() as $i => $tileGroup) {
             if ($i === 0) {
-                $tileGroup->setHidden(false);
+
+                // hide the first tile group (the overview), but only if the depth is not 1,
+                // otherwise we get issues with landing pages etc, as they dont display any data then
+                if ($this->getWidget()->getDepth() === 1) {
+                    $tileGroup->setHidden(false);
+                    continue;
+                }
+
+                $tileGroup->setHidden(true);
                 continue;
             }
             $js .= $this->buildJsIconTabBarItem($tileGroup);
@@ -145,7 +153,6 @@ JS;
 
     protected function hasIconTabBar() : bool
     {
-        //return $this->getWidget()->getDepth() > 1;
         return true;
     }
     

--- a/Facades/Elements/UI5NavTiles.php
+++ b/Facades/Elements/UI5NavTiles.php
@@ -142,7 +142,12 @@ JS;
 
     protected function buildJsIconTabBarItem(Tiles $tileGroup) : string
     {
-        $tabCaption = StringDataType::substringAfter($tileGroup->getCaption(), ' > ');
+        $tabCaption = $tileGroup->getCaption();
+
+        // only show the last part of the caption, if there is a parent path included (parent > child)
+        if ($this->getWidget()->getShowParentPath()) {
+            $tabCaption = StringDataType::substringAfter($tabCaption, ' > ');
+        }
         $tabElement = $this->getFacade()->getElement($tileGroup);
         return <<<JS
 

--- a/Facades/Elements/UI5NavTiles.php
+++ b/Facades/Elements/UI5NavTiles.php
@@ -140,7 +140,7 @@ JS;
 
                 // hide the first tile group (the overview), but only if the depth is not 1,
                 // otherwise we get issues with landing pages etc, as they dont display any data then
-                if ($this->getWidget()->getDepth() === 1 || count($this->getWidget()->getTiles()) === 1) {
+                if ($this->getWidget()->getDepth() === 1 || count($this->getWidget()->getTiles()) === 1 || $this->getWidget()->getShowOverviewGroup() === true) {
                     $tileGroup->setHidden(false);
                     continue;
                 }

--- a/Facades/js/openui5.template.css
+++ b/Facades/js/openui5.template.css
@@ -518,8 +518,9 @@ the entire text from disappearing (...) if the text overflows */
 
 .navTilesToolbar .exf-navtiles-tab-header {
     min-width: 14rem;
-    max-width: none;
-    flex: 1 1 14rem;
+    max-width: 75%;
+    width: 75%;
+    flex: 0 1 75%;
 }
 
 .navTilesToolbar .exf-navtiles-search {
@@ -530,27 +531,16 @@ the entire text from disappearing (...) if the text overflows */
     padding-top: 0.5rem;
 }
 
-/* todo: fix mobile */
+/* mobile layout for navtiles searchbar */
 @media (max-width: 1024px) {
-    .navTilesToolbar {
-        flex-wrap: nowrap;
-        align-items: center;
-    }
-
     .navTilesToolbar .sapMTBSpacer {
-        display: block;
-    }
-
-    .navTilesToolbar .exf-navtiles-tab-header {
-        min-width: 14rem;
-        max-width: none;
-        flex: 1 1 14rem;
+        display: none;
     }
 
     .navTilesToolbar .exf-navtiles-search {
-        width: 14rem;
-        min-width: 14rem;
-        flex: 0 0 14rem;
+        width: 100%;
+        min-width: 0;
+        flex: 0 1 18rem;
     }
 }
 

--- a/Facades/js/openui5.template.css
+++ b/Facades/js/openui5.template.css
@@ -489,14 +489,24 @@ the entire text from disappearing (...) if the text overflows */
     color: transparent;
 }
 
-/* NavTiles IconTabBar */
-.tileHeaderMarginTop {margin-top: 50px;}
+/* NavTiles IconTabBar & SearchFilter */
+[id*="-content"] {scroll-padding-top: 50px;}
 .customHeader {box-shadow: none;}
+.responsiveFlexbox {position: fixed; z-index: 1; width: 100%; justify-content: space-between; padding-right:1rem; box-shadow: 0 4px 6px -2px rgba(0, 0, 0, 0.2); margin: auto;}
+@media (max-width: 1024px) {
+    .responsiveFlexbox {flex-direction: column;padding-bottom: 12px;}
+    [id*="-content"] {scroll-padding-top: 90px;}
+    #__field0 {padding-left: 1rem;}
+}
+/* NavTiles SearchFilter */
+[class*="sapMSF"] {height: 2rem !important;margin-top: 2px;}
+.sapMSFB {padding-top: 3px !important;}
+/* TODO remove this? What is better: fixed or sticky?
 .responsiveFlexbox {position: sticky; z-index: 1000; width: auto;}
 @media (max-width: 966px) {
     .responsiveFlexbox {flex-direction: column;}
     .customSearchField {padding-left: 16px;padding-right: 16px;}
-}
+}*/
 
 /* ColorPalette */
 .exf-colorPalette {

--- a/Facades/js/openui5.template.css
+++ b/Facades/js/openui5.template.css
@@ -490,23 +490,69 @@ the entire text from disappearing (...) if the text overflows */
 }
 
 /* NavTiles IconTabBar & SearchFilter */
-[id*="-content"] {scroll-padding-top: 50px;}
-.customHeader {box-shadow: none;}
-.responsiveFlexbox {position: fixed; z-index: 1; width: 100%; justify-content: space-between; padding-right:1rem; box-shadow: 0 4px 6px -2px rgba(0, 0, 0, 0.2); margin: auto;}
-@media (max-width: 1024px) {
-    .responsiveFlexbox {flex-direction: column;padding-bottom: 12px;}
-    [id*="-content"] {scroll-padding-top: 90px;}
-    #__field0 {padding-left: 1rem;}
+.customHeader {
+    box-shadow: none;
+} 
+
+/* set the toolbar sticky/to the top of the control */
+.navTilesToolbar {
+    z-index: 10;
+    background: var(--sapBackgroundColor);
+    position: sticky;
+    top: 0;
+    width: 100%;
+    height: auto;
+    min-height: 2.75rem;
+    overflow: visible;
 }
-/* NavTiles SearchFilter */
-[class*="sapMSF"] {height: 2rem !important;margin-top: 2px;}
-.sapMSFB {padding-top: 3px !important;}
-/* TODO remove this? What is better: fixed or sticky?
-.responsiveFlexbox {position: sticky; z-index: 1000; width: auto;}
-@media (max-width: 966px) {
-    .responsiveFlexbox {flex-direction: column;}
-    .customSearchField {padding-left: 16px;padding-right: 16px;}
-}*/
+
+.navTilesToolbar .sapMBarChild,
+.navTilesToolbar .sapMBarChildWrapper,
+.navTilesToolbar .sapMITH,
+.navTilesToolbar .sapMITHWrapper {
+    /* otherwise parts of the tabBar (the selected inicators) are clipped */
+    height: 100%;
+    overflow: visible;
+    border-bottom: solid .0625rem var(--sapGroup_TitleBorderColor);
+}
+
+.navTilesToolbar .exf-navtiles-tab-header {
+    min-width: 14rem;
+    max-width: none;
+    flex: 1 1 14rem;
+}
+
+.navTilesToolbar .exf-navtiles-search {
+    width: 18rem;
+    min-width: 18rem;
+    flex: 0 0 18rem;
+    border-bottom: none;
+    padding-top: 0.5rem;
+}
+
+/* todo: fix mobile */
+@media (max-width: 1024px) {
+    .navTilesToolbar {
+        flex-wrap: nowrap;
+        align-items: center;
+    }
+
+    .navTilesToolbar .sapMTBSpacer {
+        display: block;
+    }
+
+    .navTilesToolbar .exf-navtiles-tab-header {
+        min-width: 14rem;
+        max-width: none;
+        flex: 1 1 14rem;
+    }
+
+    .navTilesToolbar .exf-navtiles-search {
+        width: 14rem;
+        min-width: 14rem;
+        flex: 0 0 14rem;
+    }
+}
 
 /* ColorPalette */
 .exf-colorPalette {


### PR DESCRIPTION
- new tabbar for easier navigation
- new searchbar that toggles tiles hidden/visible based on search
- autofocus on searchfield when opening a navtiles widget
- overview panel (first tiles group) is hidden by default, but can be configured using new uxon properties
- panel caption are now by default not the breadcrumb-style, but just the child-caption 

Needs Core Update https://github.com/ExFace/Core/pull/787 