### PR TITLE
FIX NavTiles: scrolling via tabbar sometimes not working

### DIFF
--- a/Facades/Elements/UI5NavTiles.php
+++ b/Facades/Elements/UI5NavTiles.php
@@ -87,13 +87,15 @@ JS;
 
                             // Find the corresponding panel that matches the key and scroll it into view
                             var oPanel = sap.ui.getCore().byId(sKey);
-                            if (oPanel && oPanel.getDomRef()) {
-                                oPanel.getDomRef().scrollIntoView({ behavior: "smooth" , block: "start" });
+                            var oPanelDom = oPanel ? oPanel.getDomRef() : null;
+                            if (!oPanelDom) {
+                                return;
                             }
+                            oPanelDom.scrollIntoView({ behavior: "smooth" , block: "start" });
 
                             // briefly flash the panel heading to give visual feedback
                             // (useful for short sections that don't actually scroll)
-                            var oHeading = oPanel.getDomRef().querySelector(".sapMPanelHdr, .sapMPanelHeader, .sapUiPanelHdr");
+                            var oHeading = oPanelDom.querySelector(".sapMPanelHdr, .sapMPanelHeader, .sapUiPanelHdr");
                             if (oHeading) {
                                 oHeading.classList.add("exf-navtiles-heading-flash");
                                 setTimeout(function() {

--- a/Facades/Elements/UI5NavTiles.php
+++ b/Facades/Elements/UI5NavTiles.php
@@ -81,14 +81,16 @@ JS;
                 new sap.m.IconTabHeader("{$this->getId()}_iconTabHeader", {
                     mode: "Inline",
                     select: function(oEvent) {
-                        // Get the selected key
-                        var sKey = oEvent.getParameter("key");
+                        setTimeout(function() {
+                            // Get the selected key
+                            var sKey = oEvent.getParameter("key");
 
-                        // Find the corresponding panel that matches the key and scroll it into view
-                        var oPanel = sap.ui.getCore().byId(sKey);
-                        if (oPanel && oPanel.getDomRef()) {
-                            oPanel.getDomRef().scrollIntoView({ behavior: "smooth" , block: "start" });
-                        }
+                            // Find the corresponding panel that matches the key and scroll it into view
+                            var oPanel = sap.ui.getCore().byId(sKey);
+                            if (oPanel && oPanel.getDomRef()) {
+                                oPanel.getDomRef().scrollIntoView({ behavior: "smooth" , block: "start" });
+                            }
+                        }, 0);
                     },
                     items: [
                         {$this->buildJsIconTabBarItems()}

--- a/Facades/Elements/UI5NavTiles.php
+++ b/Facades/Elements/UI5NavTiles.php
@@ -134,6 +134,75 @@ JS;
                 if (oSearch) {
                     setTimeout(function() { oSearch.focus(); }, 0);
                 }
+
+                // scrollObserver: highlight the matching tab when the user scrolls to a section
+                // (register this once per toolbar instance)
+                if (oToolbar.data("_exfScrollObserverActive")) {
+                    return;
+                }
+                oToolbar.data("_exfScrollObserverActive", true);
+
+                // short delay so all child panels are rendered before we observe them
+                setTimeout(function() {
+                    var oTabHeader = sap.ui.getCore().byId("{$this->getId()}_iconTabHeader");
+                    if (!oTabHeader || !oTabHeader.getItems().length) { return; }
+
+                    var oToolbarDom = oToolbar.getDomRef();
+                    var iToolbarHeight = oToolbarDom ? Math.round(oToolbarDom.getBoundingClientRect().height) : 44;
+
+                    // find the nearest scrollable ancestor; null = viewport (required by IntersectionObserver)
+                    var oScrollRoot = null;
+                    var oDom = oToolbarDom;
+                    while (oDom && oDom !== document.body) {
+                        oDom = oDom.parentElement;
+                        if (!oDom) { break; }
+                        var sOverflow = window.getComputedStyle(oDom).overflowY;
+                        if (sOverflow === "auto" || sOverflow === "scroll") {
+                            oScrollRoot = oDom;
+                            break;
+                        }
+                    }
+
+                    // track which panel keys are currently inside the active viewport zone
+                    var aVisibleKeys = [];
+
+                    var oObserver = new IntersectionObserver(function(aEntries) {
+                        aEntries.forEach(function(oEntry) {
+                            var sId = oEntry.target.id;
+                            if (oEntry.isIntersecting) {
+                                if (aVisibleKeys.indexOf(sId) === -1) { aVisibleKeys.push(sId); }
+                            } else {
+                                aVisibleKeys = aVisibleKeys.filter(function(k) { return k !== sId; });
+                            }
+                        });
+
+                        // always highlight the topmost visible panel if multiple are visible; 
+                        var sActiveKey = null;
+                        oTabHeader.getItems().forEach(function(oItem) {
+                            if (sActiveKey === null && aVisibleKeys.indexOf(oItem.getKey()) !== -1) {
+                                sActiveKey = oItem.getKey();
+                            }
+                        });
+
+                        if (sActiveKey && oTabHeader.getSelectedKey() !== sActiveKey) {
+                            oTabHeader.setSelectedKey(sActiveKey);
+                        }
+                    }, {
+                        root: oScrollRoot,
+                        // active zone: from just below the sticky toolbar down to 50% of the viewport
+                        rootMargin: '-' + iToolbarHeight + 'px 0px -50% 0px',
+                        threshold: 0
+                    });
+
+                    // register observer on panels
+                    oTabHeader.getItems().forEach(function(oItem) {
+                        var oPanel = sap.ui.getCore().byId(oItem.getKey());
+                        if (oPanel && oPanel.getDomRef()) {
+                            oObserver.observe(oPanel.getDomRef());
+                        }
+                    });
+                }, 200);
+
             }
         }),
 

--- a/Facades/Elements/UI5NavTiles.php
+++ b/Facades/Elements/UI5NavTiles.php
@@ -90,6 +90,16 @@ JS;
                             if (oPanel && oPanel.getDomRef()) {
                                 oPanel.getDomRef().scrollIntoView({ behavior: "smooth" , block: "start" });
                             }
+
+                            // briefly flash the panel heading to give visual feedback
+                            // (useful for short sections that don't actually scroll)
+                            var oHeading = oPanel.getDomRef().querySelector(".sapMPanelHdr, .sapMPanelHeader, .sapUiPanelHdr");
+                            if (oHeading) {
+                                oHeading.classList.add("exf-navtiles-heading-flash");
+                                setTimeout(function() {
+                                    oHeading.classList.remove("exf-navtiles-heading-flash");
+                                }, 800);
+                            }
                         }, 0);
                     },
                     items: [

--- a/Facades/js/openui5.template.css
+++ b/Facades/js/openui5.template.css
@@ -516,6 +516,15 @@ the entire text from disappearing (...) if the text overflows */
     border-bottom: solid .0625rem var(--sapGroup_TitleBorderColor);
 }
 
+@keyframes exf-navtiles-heading-flash {
+    0%   { color: var(--sapHighlightColor, #0070f2); }
+    50%  { color: var(--sapHighlightColor, #0070f2); }
+    100% { color: inherit; }
+}
+.exf-navtiles-heading-flash {
+    animation: exf-navtiles-heading-flash 0.8s ease-out forwards;
+}
+
 .navTilesToolbar .exf-navtiles-tab-header {
     min-width: 14rem;
     max-width: 75%;

--- a/Facades/js/openui5.template.css
+++ b/Facades/js/openui5.template.css
@@ -494,10 +494,18 @@ the entire text from disappearing (...) if the text overflows */
     box-shadow: none;
 } 
 
+/* show sidenavigation popups over tabbar */
+.sapTntSideNavigation  .sapTntNLPopover.sapMPopover {
+    z-index: 2 !important;
+}
+.sapTntSideNavigation  .sapTntNLCollapsed .sapTntNLI:not(.sapTntNLIDisabled):not(.sapTntNLIActive):not(.sapTntNLINoHoverEffect) [tabindex]:hover {
+    z-index: 2;
+}
+
 /* set the toolbar sticky/to the top of the control */
 .navTilesToolbar {
     z-index: 1;
-    background: var(--sapBackgroundColor);
+    background: var(--sapObjectHeader_Background) !important;
     position: sticky;
     top: 0;
     width: 100%;


### PR DESCRIPTION
- scrollTo function needed a timeout, otherwise selecting items directly from the overflow didnt scroll to the desired position
- added a brief color flash/highlight to the panel heading when a tab is selected. This way, the users get visual feedback, even if there is no scroll action (for example in Navtiles with few elements)
- now also updating the selected tab when scrolling