### PR TITLE
NEW Column-Header Filters: added support for complex operators

### DIFF
--- a/Facades/Elements/UI5DataColumn.php
+++ b/Facades/Elements/UI5DataColumn.php
@@ -129,6 +129,7 @@ JS;
     {
         $col = $this->getWidget();
         $isFilterable = $col->isFilterable() === true;
+        $filterInputTooltipJs = $this->escapeString($this->translate('WIDGET.DATATABLE.FILTER_INPUT_TOOLTIP'));
         $dataTable = $this->getFacade()->getElement($this->getWidget()->getDataWidget());
         $configurator = $this->getFacade()->getElement($dataTable->getWidget()->getConfiguratorWidget());
 
@@ -136,7 +137,6 @@ JS;
         if ($isFilterable){
             return <<<JS
             columnMenuOpen: function(oEvent) {
-
             // get column, menu and id from event params
             let sResetBtnId = oEvent.getParameter('id') + "_resetBtn";
             let oColumn = sap.ui.getCore().byId(oEvent.getParameter('id'));
@@ -148,6 +148,7 @@ JS;
 
             // columnMenuOpen fires before menu is there, so timeout prevents lifecycle issues here
             setTimeout(function() {
+                var sFilterInputTooltip = {$filterInputTooltipJs};
                 
                 // since adding menu items to the default column menu was not encouraged in documentation, wrap in try/catch
                 // see https://ui5.sap.com/1.136.9/#/api/sap.ui.table.ColumnMenu
@@ -183,6 +184,20 @@ JS;
                                 }
                             })
                         );
+                    }
+
+                    // add a tooltip to the built-in filter input to explain additional filter syntax
+                    if (sFilterInputTooltip) {
+                        try {
+                            var oFilterFieldItem = oMenu.getItems().find(function(oItem) {
+                                return oItem && typeof oItem.isA === 'function' && oItem.isA('sap.ui.unified.MenuTextFieldItem');
+                            });
+                            if (oFilterFieldItem && typeof oFilterFieldItem.setTooltip === 'function') {
+                                oFilterFieldItem.setTooltip(sFilterInputTooltip);
+                            }
+                        } catch (e) {
+                            console.warn('Could not set custom tooltip on column filter field: ', e);
+                        }
                     }
                 }
                 catch (e) {

--- a/Facades/Elements/UI5DataTable.php
+++ b/Facades/Elements/UI5DataTable.php
@@ -1090,7 +1090,11 @@ JS;
                         var sFltrProp = oColumn.getFilterProperty();
                         var sFltrVal = oEvent.getParameters().value;
                         var fnParser = oColumn.data('_exfFilterParser'); 
-                        var mFltrParsed = fnParser !== undefined ? fnParser(sFltrVal) : sFltrVal;
+                        var oParsedInput = exfTools.filter.parseOperator(String(sFltrVal));
+                        var mFltrRaw = oParsedInput.value;
+                        var mFltrParsed = fnParser !== undefined ? fnParser(mFltrRaw) : mFltrRaw;
+                        var oComponent = {$this->getController()->buildJsComponentGetter()};
+                        var oP13nMapped = oComponent.mapOperatorToP13n(oParsedInput.operator);
     
                         {$oParamsJs}['{$this->getFacade()->getUrlFilterPrefix()}' + sFltrProp] = mFltrParsed;
                         
@@ -1115,8 +1119,8 @@ JS;
                             // create new filter item if value is valid/not empty
                             var oFilterItem = new sap.m.P13nFilterItem({
                                 "columnKey": sFltrProp,
-                                "exclude": false,
-                                "operation": "Contains",
+                                "exclude": oP13nMapped.exclude,
+                                "operation": oP13nMapped.operation,
                                 "value1": mFltrParsed
                             });
     

--- a/Facades/Webapp/Component.js
+++ b/Facades/Webapp/Component.js
@@ -62,6 +62,29 @@ sap.ui.define([
 				throw 'UI5 Condintion operation "'+operation+'" cannot be mapped to a condition group operator!';
 			}
         },
+
+        /**
+         * Maps raw filter operator string to P13n operation + exclude flag.
+         * Used by header filters to convert user-entered operator syntax to P13n equivalents.
+		 * 
+		 * If no match is found, defaults to "Contains" operation with exclude=false, which results in a "like" filter.
+         * 
+         * @param {string} sOperator - Raw operator ('!==', '==', '!=', '>=', '<=', '>', '<', '=', or '')
+         * @return {object} Object with operation and exclude properties
+         */
+        mapOperatorToP13n: function(sOperator) {
+            var mOperatorMap = {
+                '!==': { operation: 'EQ', exclude: true },
+                '==': { operation: 'EQ', exclude: false },
+                '!=': { operation: 'Contains', exclude: true },
+                '>=': { operation: 'GE', exclude: false },
+                '<=': { operation: 'LE', exclude: false },
+                '>': { operation: 'GT', exclude: false },
+                '<': { operation: 'LT', exclude: false },
+                '=': { operation: 'Contains', exclude: false }
+            };
+            return mOperatorMap[sOperator] || { operation: 'Contains', exclude: false };
+        },
         
         /**
 		 * Convenience method to create and open a dialog.

--- a/Translations/exface.UI5Facade.de.json
+++ b/Translations/exface.UI5Facade.de.json
@@ -130,6 +130,7 @@
 	"WIDGET.DATATABLE.FILTER_BY_VALUE_INCLUDE": "Einschließen",
 	"WIDGET.DATATABLE.FILTER_BY_VALUE_EXCLUDE": "Ausschließen",
 	"WIDGET.DATATABLE.FILTER_BY_VALUE_CLEAR": "Filter von dieser Spalte zurücksetzen",
+	"WIDGET.DATATABLE.FILTER_INPUT_TOOLTIP": "Filtert standardmäßig, ob der Wert enthalten ist. Zusätzliche Operatoren: == genau, !== nicht genau, != enthält nicht, >=, <=, >, <. (Bsp: !==Wert)",
 	"WIDGET.DATATABLE.FILTER_CLEAR": "Filter zurücksetzen",
 	"WIDGET.DATATABLE.GO_BUTTON_TEXT": "Suchen",
 	"WIDGET.DATATABLE.OFFLINE_HINT": "Diese Daten sind nur online verfügbar!",

--- a/Translations/exface.UI5Facade.en.json
+++ b/Translations/exface.UI5Facade.en.json
@@ -131,6 +131,7 @@
 	"WIDGET.DATATABLE.FILTER_BY_VALUE_INCLUDE": "Include",
 	"WIDGET.DATATABLE.FILTER_BY_VALUE_EXCLUDE": "Exclude",
 	"WIDGET.DATATABLE.FILTER_BY_VALUE_CLEAR": "Clear filter over this column",
+	"WIDGET.DATATABLE.FILTER_INPUT_TOOLTIP": "By default, filters whether the value is contained. Additional operators: == exact, !== not exact, != not contains, >=, <=, >, <. (Example: !==Value)",
 	"WIDGET.DATATABLE.FILTER_CLEAR": "Clear filters",
 	"WIDGET.DATATABLE.GO_BUTTON_TEXT": "Search",
 	"WIDGET.DATATABLE.OFFLINE_HINT": "The requested data is only available online!",


### PR DESCRIPTION
needs https://github.com/ExFace/Core/pull/808 

Column-header filters can now support these operators, and also synch them with/show them in the advanced search tab. Plus, on hover over the filter field, a tooltip explaining the available operators is shown.

- !==
- ==
- !=
- \>=
- <=
- \>
- <
- =