### PR TITLE
NEW DataTable: synch column drag and drop with configurator

### DIFF
--- a/Facades/Elements/UI5DataConfigurator.php
+++ b/Facades/Elements/UI5DataConfigurator.php
@@ -603,75 +603,87 @@ JS;
                         })
                     },
                     beforeNavigationTo: function(oEvent) {
-                        {$this->buildJsTabColumnsUpdate('oEvent.getSource()')}                        
+                        var fnUpdateColumns = this.data('_exfTabColumnsUpdate');
+                        if (typeof fnUpdateColumns === 'function') {
+                            fnUpdateColumns.call(this, false);
+                        }
                     }
-                }),
+                })
+                .data('_exfTabColumnsUpdate', {$this->buildJsTabColumnsUpdateFunction()})
+                ,
 JS;
     }
     
-    protected function buildJsTabColumnsUpdate(string $oPanelJs, bool $resetSelection = false) : string
+    protected function buildJsTabColumnsUpdateFunction() : string
     {
-        /* This script sorts the columns in the panel's list to be sorted exactly the way, they
-         * are positioned in the table - regardless of their visibility. By default, unchecked
-         * columns are placed at the end of the the list. This forces the user to move them
-         * after enabling. This fix makes sure, the position of the column is kept when enabling/disabling
-         * and allows table designers to position optional columns meaningfully.
-         */
-        if ($resetSelection === true) {
-            $resetSelection = "oItem.persistentSelected = oColConfig.visibleInitially; oColConfig.visible = oColConfig.visibleInitially; oItem.persistentIndex = iItemIdx";
-        } else {
-            $resetSelection = '';
-        }
         return <<<JS
-                var oPanel = $oPanelJs;
+function(bResetSelection) {
+    /* This script sorts the columns in the panel's list to be sorted exactly the way, they
+     * are positioned in the table - regardless of their visibility. By default in UI5, unchecked
+     * columns are placed at the end of the the list. This forces the user to move them
+     * after enabling. This fix makes sure, the position of the column is kept when enabling/disabling
+     * and allows table designers to position optional columns meaningfully.
+     */
+    var oPanel = this;
 
-                // settimeout needed here bc. otherwise the data is not there yet, 
-                // and changes are then only applied when panel is openend for the second time
-                setTimeout(function(){
+    if (bResetSelection === true) {
+        bResetSelection = function(oItem, oColConfig, iItemIdx) {
+            oItem.persistentSelected = oColConfig.visibleInitially;
+            oColConfig.visible = oColConfig.visibleInitially;
+            oItem.persistentIndex = iItemIdx;
+        };
+    } else {
+        bResetSelection = function() {};
+    }
+
+    // settimeout needed here bc. otherwise the data is not there yet,
+    // and changes are then only applied when panel is openend for the second time
+    setTimeout(function(){
+        try {
+                let oTable = null;
+                if (oPanel.getAggregation('content')[1] !== undefined){
+                    oTable = oPanel.getAggregation('content')[1].getAggregation('content')[0];
+                }
+                else{
+                    // UI5-Upgrade - structure changed, need to get table content differently
+                    oTable = oPanel.getAggregation('content')[0];
+                }
+                var oTableModel = oTable.getModel();
+                var oConfigModel = oPanel.getModel('{$this->getModelNameForConfig()}');
+                if (oTableModel === undefined || oConfigModel === undefined) return;
+                
                     try {
-                            let oTable = null;
-                            if (oPanel.getAggregation('content')[1] !== undefined){
-                                oTable = oPanel.getAggregation('content')[1].getAggregation('content')[0];
-                            }
-                            else{
-                                // UI5-Upgrade - structure changed, need to get table content differently
-                                oTable = oPanel.getAggregation('content')[0];
-                            }
-                            var oTableModel = oTable.getModel();
-                            var oConfigModel = oPanel.getModel('{$this->getModelNameForConfig()}');
-                            if (oTableModel === undefined || oConfigModel === undefined) return;
-                            
-                                try {
-                                    var aColsConfig = oConfigModel.getProperty('/columns');
-                                    
-                                    // only use items that are toggleable
-                                    var oVisibleFilter = new sap.ui.model.Filter("toggleable", sap.ui.model.FilterOperator.EQ, true);
-                                    oPanel.getBinding("items").filter(oVisibleFilter);
-                                    
-                                    var aItems = oTableModel.getProperty('/items');
-                                    var aItemsNew = [];
-                                    
-                                    aColsConfig.forEach(function(oColConfig){
-                                        aItems.forEach(function(oItem, iItemIdx){
-                                            if (oItem.columnKey === oColConfig.column_id) {
-                                                $resetSelection;
-                                                aItemsNew.push(oItem);
-                                                return;
-                                            }
-                                        })
-                                    });
-                                    oTableModel.setProperty('/items', aItemsNew);
-                                    // update counts of selected items, else the counter is wrong after a reset
-                                    oPanel._updateCounts(aItemsNew);
-                                } catch (e) {
-                                    console.warn('Cannot properly sort columns for personalization - using default sorting: ', e);
+                        var aColsConfig = oConfigModel.getProperty('/columns');
+                        
+                        // only use items that are toggleable
+                        var oVisibleFilter = new sap.ui.model.Filter("toggleable", sap.ui.model.FilterOperator.EQ, true);
+                        oPanel.getBinding("items").filter(oVisibleFilter);
+                        
+                        var aItems = oTableModel.getProperty('/items');
+                        var aItemsNew = [];
+                        
+                        aColsConfig.forEach(function(oColConfig){
+                            aItems.forEach(function(oItem, iItemIdx){
+                                if (oItem.columnKey === oColConfig.column_id) {
+                                    oItem.persistentSelected = oColConfig.visible;
+                                    bResetSelection(oItem, oColConfig, iItemIdx);
+                                    aItemsNew.push(oItem);
+                                    return;
                                 }
-                        } 
-                    catch (e) {
+                            })
+                        });
+                        oTableModel.setProperty('/items', aItemsNew);
+                        // update counts of selected items, else the counter is wrong after a reset
+                        oPanel._updateCounts(aItemsNew);
+                    } catch (e) {
                         console.warn('Cannot properly sort columns for personalization - using default sorting: ', e);
                     }
-                }, 0); 
-                        
+            } 
+        catch (e) {
+            console.warn('Cannot properly sort columns for personalization - using default sorting: ', e);
+        }
+    }, 0); 
+}
 JS;
     }
         
@@ -1318,7 +1330,14 @@ JS;
             $resetColumns = <<<JS
 // reset columns
                 oCurrentModel.setProperty('/columns', JSON.parse(JSON.stringify(oInitModel.getProperty('/columns'))));
-                {$this->buildJsTabColumnsUpdate("sap.ui.getCore().byId('{$this->getId()}_ColumnsPanel')", true)}
+
+                // reset the columns panel UI
+                var oColumnsPanel = sap.ui.getCore().byId('{$this->getId()}_ColumnsPanel');
+                var fnUpdateColumns = oColumnsPanel && oColumnsPanel.data('_exfTabColumnsUpdate');
+                if (typeof fnUpdateColumns === 'function') {
+                    fnUpdateColumns.call(oColumnsPanel, true);
+                }
+
                 {$refreshP13n}
 JS;
         } else {

--- a/Facades/Elements/UI5DataTable.php
+++ b/Facades/Elements/UI5DataTable.php
@@ -771,6 +771,43 @@ JS;
         		sort: {$controller->buildJsMethodCallFromView('onLoadData', $this)},
                 rowSelectionChange: function (oEvent) { {$this->buildJsPropertySelectionChange('oEvent')} },
                 firstVisibleRowChanged: {$controller->buildJsEventHandler($this, self::EVENT_NAME_FIRST_VISIBLE_ROW_CHANGED, true)},
+                columnMove: function (oEvent) {
+                    // store drag and drop column re-ordering in the model/p13n dialogue, so it can be saved in a setup
+                    setTimeout(() => {
+                        let oDialog = sap.ui.getCore().byId('{$this->getP13nElement()->getId()}');
+                        if (!oDialog) return;
+                        let oP13nModel = oDialog.getModel('{$this->getConfiguratorElement()->getModelNameForConfig()}');
+                        if (!oP13nModel) return;
+                        let aModelCols = oP13nModel.getProperty('/columns') || [];
+                        if (!aModelCols.length) return;
+
+                        // Build new /columns order directly from the table (which already reflects the drag/drop).
+                        // Map column configs by their ID for quick lookup
+                        let oColumnConfigById = {};
+                        aModelCols.forEach(o => { if (o && o.column_id) oColumnConfigById[o.column_id] = o; });
+                        
+                        // Iterate through visible table columns and rebuild the model in their current order
+                        let mSeen = {}, aNewModelCols = [];
+                        (this.getColumns ? this.getColumns() : []).forEach(oCol => {
+                            let oColConfig = oColumnConfigById[oCol.getId()];
+                            if (oColConfig && !mSeen[oCol.getId()]) { aNewModelCols.push(oColConfig); mSeen[oCol.getId()] = true; }
+                        });
+                        
+                        // Append model-only entries (hidden/optional columns not rendered in the table) at the end
+                        aModelCols.forEach(o => { if (o && o.column_id && !mSeen[o.column_id]) aNewModelCols.push(o); });
+
+                        // update the model
+                        oP13nModel.setProperty('/columns', aNewModelCols);
+                        oP13nModel.refresh(true);
+
+                        // update the UI of the columns panel in the configurator, to refelect the new column order
+                        var oColumnsPanel = sap.ui.getCore().byId('{$this->getP13nElement()->getIdOfColumnsPanel()}');
+                        var fnUpdateColumns = oColumnsPanel && oColumnsPanel.data('_exfTabColumnsUpdate');
+                        if (typeof fnUpdateColumns === 'function') {
+                            fnUpdateColumns.call(oColumnsPanel, false);
+                        }
+                    }, 0);
+                },
         		columnResize: function (oEvent) {
                     // skip if the table is currently auto-resizing
                     if (this.data("_exfIsAutoResizing")) {

--- a/Facades/js/exfSetupManager.js
+++ b/Facades/js/exfSetupManager.js
@@ -746,29 +746,11 @@
 
                 // toggle checkboxes in columns tab according to setup
                 // otherwise the UI doesnt seem to get updated, since we dont manually interact with the checkboxes
-                let oTable = null;
-                if (oDialog.getAggregation('content')[1] !== undefined){
-                    oTable = oDialog.getAggregation('content')[1].getAggregation('content')[0];
+                // for this, we use the update function attached to the panel, see Ui5DataConfigurator
+                let fnUpdateColumnsPanel = oDialog && oDialog.data('_exfTabColumnsUpdate');
+                if (typeof fnUpdateColumnsPanel === 'function') {
+                    fnUpdateColumnsPanel.call(oDialog, false);
                 }
-                else{
-                    // UI5-Upgrade - structure changed, need to get table content differently
-                    oTable = oDialog.getAggregation('content')[0];
-                }
-                
-                let oTableModel = oTable.getModel();
-                let aColsConfig = oModel.getProperty('/columns');
-                let oVisibleFilter = new sap.ui.model.Filter("toggleable", sap.ui.model.FilterOperator.EQ, true);
-                oDialog.getBinding("items").filter(oVisibleFilter);
-                let aItems = oTableModel.getProperty('/items');
-                
-                aColsConfig.forEach(function(oColConfig){
-                    aItems.forEach(function(oItem, iItemIdx){
-                        if (oItem.columnKey === oColConfig.column_id) {
-                            oItem.persistentSelected = oColConfig.visible; 
-                            return;
-                        }
-                    })
-                }); 
 
             }
             if (oSetupUxon.sorters !== undefined) {


### PR DESCRIPTION
- when drag-and-dropping columns, synch their new position with the configurator
- refactored buildJsTabColumnsUpdate() to be a JS function attached to the Column Panel, so it can be re-used to update columns panel accordingly