### PR TITLE
FIX LookupDialogues: filter widget links were broken

### DIFF
--- a/Facades/Elements/UI5AbstractElement.php
+++ b/Facades/Elements/UI5AbstractElement.php
@@ -548,7 +548,7 @@ JS;
         if ($this->controller === null) {
             if (null !== $parent = $this->getWidget()->getParent()) {
                 $parentEl = $this->getFacade()->getElement($parent);
-                $this->controller = $parentEl->getController();
+                $this->controller = $parentEl->getController(); // caches controller, but doesnt dispatch event (?)
             } else {
                 throw new UI5ControllerNotInitializedException('No controller was initialized for page "' . $this->getWidget()->getPage()->getAliasWithNamespace() . '"!');
             }
@@ -578,14 +578,53 @@ JS;
      */
     public function setController(UI5ControllerInterface $controller) : UI5AbstractElement
     {
-        if (! $this->controller === null) {
+        // NOTE: the original check 'if (! $this->controller === null)' was a bug, because PHP
+        // evaluates it as 'if ((! $this->controller) === null)', which is always false. 
+        // now: a controller may only be assigned once. Re-assigning the
+        // exact same controller is tolerated, but switching to a different one gives an error.
+        if ($this->controller !== null && $this->controller !== $controller) {
             throw new LogicException('Cannot change the controller of a UI5 element after it had been set initially!');
         }
         $this->controller = $controller;
         $this->getWorkbench()->eventManager()->dispatch(new OnControllerSetEvent($controller, $this));
         return $this;
     }
-    
+
+    /**
+     * Re-dispatches OnControllerSetEvent for this element to flush callbacks parked via addOnControllerSet().
+     *
+     * Callbacks registered through `addOnControllerSet()` while no controller was available yet are parked
+     * and only executed when an `OnControllerSetEvent` is dispatched (i.e. from `setController()`). That event
+     * is a one-shot: a callback parked AFTER the controller was initially set never runs, because the event
+     * is not replayed for late subscribers.
+     *
+     * This becomes a problem for cross-view live references: a dependent widget in a lazily loaded view (e.g.
+     * a filter inside a lookup dialog) registers its `onChange` handler on a SOURCE widget that lives in
+     * another (e.g. the calling) view. That registration must happen while the source view's controller is
+     * still collecting scripts - i.e. during that view's render. Calling this method on the view root forces
+     * the parked callbacks for that subtree to run at the right moment.
+     *
+     * If no controller exists for this element yet, one is created (which dispatches the event as well).
+     *
+     * @return UI5AbstractElement
+     */
+    public function flushControllerSetListeners() : UI5AbstractElement
+    {
+        try {
+            $controller = $this->getController();
+        } catch (UI5ControllerNotInitializedException $e) {
+            // No controller for this subtree yet - creating one dispatches OnControllerSetEvent
+            // and flushes the parked queue.
+            $this->getFacade()->createController($this);
+            return $this;
+        }
+
+        // A controller already exists, re-dispatch the event to flush any callbacks that were
+        // parked after it was initially set.
+        $this->getWorkbench()->eventManager()->dispatch(new OnControllerSetEvent($controller, $this));
+        return $this;
+    }
+
     public final function buildHtmlHeadTags()
     {
         return [];

--- a/Facades/Elements/UI5Button.php
+++ b/Facades/Elements/UI5Button.php
@@ -813,17 +813,11 @@ JS, false);
      */
     protected function buildJsClickSendToWidget(SendToWidget $action, string $jsRequestData) : string
     {
-        // Flush controller-set callbacks for the PAGE ROOT (not just this view) so that cross-view
-        // live references get registered correctly. The dependent widget of such a reference (e.g. a
-        // filter inside this lookup dialog) lives in this view, but its SOURCE widget (e.g. a value in
-        // the calling form) lives OUTSIDE this view, higher up in the page tree. To attach the onChange
-        // handler, that source widget needs a controller - and in this separately loaded http request (lookup dialog)
-        // only this dialog view has one. Creating/flushing at the page root gives the out-of-view source a
-        // controller and flushes the dependent's parked registration in one go
-        // see UI5AbstractElement::flushControllerSetListeners() for details.
-        // NOTE: PHP rebuilds the widget/element tree from scratch on every request, so the page root has no controller
-        // since the lookup dialogue is a seperate request.
-        $this->getFacade()->getElement($this->getWidget()->getPage()->getWidgetRoot())->flushControllerSetListeners();
+        // NOTE: cross-view live references (e.g. a filter inside this lookup dialog referencing a value
+        // in the calling form) used to be wired up from here by flushing the page-root controller. That
+        // responsibility now lives in the live-reference registration itself - see
+        // UI5Value::registerLiveReferenceAtLinkedElement(), which ensures the source widget's view root
+        // has a controller before attaching the onChange handler. So nothing extra is needed here (?)
         return $this->buildJsClickSendToWidgetViaTrait($action, $jsRequestData);
     }
     

--- a/Facades/Elements/UI5Button.php
+++ b/Facades/Elements/UI5Button.php
@@ -813,6 +813,17 @@ JS, false);
      */
     protected function buildJsClickSendToWidget(SendToWidget $action, string $jsRequestData) : string
     {
+        // Flush controller-set callbacks for the PAGE ROOT (not just this view) so that cross-view
+        // live references get registered correctly. The dependent widget of such a reference (e.g. a
+        // filter inside this lookup dialog) lives in this view, but its SOURCE widget (e.g. a value in
+        // the calling form) lives OUTSIDE this view, higher up in the page tree. To attach the onChange
+        // handler, that source widget needs a controller - and in this separately loaded http request (lookup dialog)
+        // only this dialog view has one. Creating/flushing at the page root gives the out-of-view source a
+        // controller and flushes the dependent's parked registration in one go
+        // see UI5AbstractElement::flushControllerSetListeners() for details.
+        // NOTE: PHP rebuilds the widget/element tree from scratch on every request, so the page root has no controller
+        // since the lookup dialogue is a seperate request.
+        $this->getFacade()->getElement($this->getWidget()->getPage()->getWidgetRoot())->flushControllerSetListeners();
         return $this->buildJsClickSendToWidgetViaTrait($action, $jsRequestData);
     }
     

--- a/Facades/Elements/UI5Value.php
+++ b/Facades/Elements/UI5Value.php
@@ -9,6 +9,7 @@ use exface\Core\Widgets\Input;
 use exface\Core\Interfaces\Widgets\iShowDataColumn;
 use exface\Core\Interfaces\Widgets\iHaveValue;
 use exface\Core\DataTypes\NumberDataType;
+use exface\UI5Facade\Exceptions\UI5ControllerNotInitializedException;
 
 /**
  * Generates sap.m.Text controls for Value widgets
@@ -487,6 +488,26 @@ JS;
      */
     public function registerLiveReferenceAtLinkedElement() 
     {
+        // Make sure the source's view root has a controller before attaching to it.
+        // otherwise, create one and flush any parked onChange registrations for the source widget.
+        // Idea here is: Flush controller-set callbacks for the PAGE ROOT (not just this view) so that cross-view
+        // live references get registered correctly. The dependent widget of such a reference (e.g. a
+        // filter inside this lookup dialog) lives in this view, but its SOURCE widget (e.g. a value in
+        // the calling form) lives OUTSIDE this view, higher up in the page tree. To attach the onChange
+        // handler, that source widget needs a controller - and in this separately loaded http request (lookup dialog)
+        // only this dialog view has one. Creating/flushing at the page root gives the out-of-view source a
+        // controller and flushes the dependent's parked registration in one go
+        // see UI5AbstractElement::flushControllerSetListeners() for details.
+        if (null !== $linkedElement = $this->getLinkedFacadeElement()) {
+            try {
+                $linkedElement->getController();
+            } catch (UI5ControllerNotInitializedException $e) {
+                $this->getFacade()
+                    ->getElement($linkedElement->getWidget()->getPage()->getWidgetRoot())
+                    ->flushControllerSetListeners();
+            }
+        }
+
         $this->registerLiveReferenceAtLinkedElementViaTrait();
         // Also refresh the live reference each time the view is prefilled!
         // But use setTimeout() to make sure all widgets binding-events affected


### PR DESCRIPTION
Note: in some cases (like referencing a widget outside the view in a lookup dialogue, for a filter, or similar). Creating a root-level controller seems to be essential for the widget-link logic to work at all.

- added the createController logic for the root level back in, but within a guard, so it doesnt re-create already exisiting controllers
- moved this logic from the Button (sendToWidget) into the UI5Value->registerLiveReferenceAtLinkedElement
- extracted the creation into a seperate method that either re-dispatches the event (if controller exists) or creates it