### PR TITLE
FIX InputSelect: multiselect boolean wasnt set correctly

### DIFF
--- a/Facades/Elements/UI5InputSelect.php
+++ b/Facades/Elements/UI5InputSelect.php
@@ -100,6 +100,9 @@ JS;
                     case $val === null:
                         $value = '[]';
                         break;
+                    case is_bool($val) === true:
+                        $value = $val === true ? '["1"]' : '["0"]';
+                        break;
                     case (stripos($val, $widget->getMultiSelectValueDelimiter()) !== false):
                         $vals = explode($widget->getMultiSelectValueDelimiter(), $val);
                         $value = json_encode($vals);


### PR DESCRIPTION
boolean values of multiselects werent handeled correctly in the ui5 constructor, and caused un-removable empty values 