### PR TITLE
FIX DataSpreadsheet: dropdown arrow sometimes overlapping text

### DIFF
--- a/Facades/js/openui5.template.css
+++ b/Facades/js/openui5.template.css
@@ -202,15 +202,26 @@ table.jexcel > tbody > tr > td.jexcel_dropdown.exf-dropdown-hitbox-hover:not(.re
     background-color: rgba(0, 0, 0, 0.05);
 }
 
-/* flip arrow when dropdown is open */
+/* keep padding so text does not overlap the arrow */
 table.jexcel .jdropdown-default.jdropdown-focus .jdropdown-header {
+    padding-right: 35px;
     background-color: transparent;
+    background-image: none;
+}
+
+/* flip the cell arrow when the dropdown is open */
+table.jexcel > tbody > tr > td.jexcel_dropdown:has(.jdropdown-focus) {
     background-image: url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath fill='none' d='M0 0h24v24H0V0z'/%3E%3Cpath d='M7 10l5 5 5-5H7z' fill='gray' transform='rotate(180 12 12)'/%3E%3C/svg%3E");
 }
 
 /* dropdown in header should not have white background */
 table.jexcel > thead .jdropdown{
     background-color: #dcdcdc;
+}
+
+/* add padding to dropdown cells, to avoid overlap with text and dropdown arrow */
+table.jexcel > tbody > tr > td.jexcel_dropdown {
+    padding-right: 35px;
 }
 
 /* replace filter icon */


### PR DESCRIPTION
added extra padding, so that to dropdown arrow doesnt overlap text, especially with the new auto_column_width property 