### PR TITLE
FIX DataConfigurator: show columns as toggleable based on hidden_if

### DIFF
--- a/Facades/Elements/UI5DataColumn.php
+++ b/Facades/Elements/UI5DataColumn.php
@@ -367,6 +367,7 @@ JS;
                     .data('_exfDataColumnName', '{$col->getDataColumnName()}')
 					.data('_exfHiddenColumn', {$this->escapeBool($col->isHidden())})
                     .data('_exfHiddenIfColumn', {$this->escapeBool($col->getHiddenIf() !== null)})
+                    {$this->buildJsHiddenIfEvaluatorData($col)}
 					.data('_exfCaption', {$captionJs})
 JS;
         
@@ -388,6 +389,35 @@ JS;
         }
         
         return '';
+    }
+
+    /**
+     * Returns a `.data('_exfHiddenIfEval', function(){...})` snippet that attaches a live evaluator
+     * for the column's `hidden_if` condition to the column control - or an empty string if the
+     * column has no `hidden_if`.
+     * 
+     * The attached function returns TRUE when the condition currently resolves to hidden, and FALSE otherwise
+     * 
+     * @param DataColumn $col
+     * @return string
+     */
+    protected function buildJsHiddenIfEvaluatorData(DataColumn $col) : string
+    {
+        $hiddenIf = $col->getHiddenIf();
+        if ($hiddenIf === null) {
+            return '';
+        }
+        try {
+            $ifJs = $this->buildJsConditionalPropertyIf($hiddenIf->getConditionGroup());
+        } catch (\Throwable $e) {
+            // If the condition cannot be rendered to JS (e.g. unsupported expression), skip it
+            // the column will simply be treated as not hidden by condition.
+            return '';
+        }
+        return <<<JS
+
+                    .data('_exfHiddenIfEval', function(){ return ({$ifJs}); })
+JS;
     }
                         
     protected function buildJsPropertyVisibile()

--- a/Facades/Elements/UI5DataConfigurator.php
+++ b/Facades/Elements/UI5DataConfigurator.php
@@ -655,6 +655,29 @@ function(bResetSelection) {
                     try {
                         var aColsConfig = oConfigModel.getProperty('/columns');
                         
+                        // Set toggleability for hidden_if columns in configurator:
+                        // a column with a hidden_if should only appear in the configurator (be toggleable)
+                        // if its condition resolves to false at runtime (the column is not hidden; so its either optional or visible and MUST be toggleable).
+                        aColsConfig.forEach(function(oColConfig) {
+                            if (oColConfig.has_hidden_if) {
+                                var oColElement = sap.ui.getCore().byId(oColConfig.column_id);
+                                var fnEvalHiddenIf = oColElement && typeof oColElement.data === 'function' ? oColElement.data('_exfHiddenIfEval') : null;
+                                var bHidden = false;
+
+                                // get the hidden_if evaluator function from the column element and call it
+                                if (typeof fnEvalHiddenIf === 'function') {
+                                    try {
+                                        bHidden = fnEvalHiddenIf() === true;
+                                    } catch (e) {
+                                        console.warn('Could not evaluate hidden_if for column ' + oColConfig.column_id + ': ', e);
+                                        bHidden = false;
+                                    }
+                                }
+                                // show column in configurator, only if hidden_if is false (column is not hidden)
+                                oColConfig.toggleable = ! bHidden;
+                            }
+                        });
+                        
                         // only use items that are toggleable
                         var oVisibleFilter = new sap.ui.model.Filter("toggleable", sap.ui.model.FilterOperator.EQ, true);
                         oPanel.getBinding("items").filter(oVisibleFilter);
@@ -754,7 +777,8 @@ JS;
                     "caption" => $col->getCaption(),
                     "visible" => $col->isHidden() || $col->getVisibility() === EXF_WIDGET_VISIBILITY_OPTIONAL ? false : true,
                     "visibleInitially" => $col->isHidden() || $col->getVisibility() === EXF_WIDGET_VISIBILITY_OPTIONAL ? false : true,
-                    "toggleable" => $col->isHidden() ? false : true
+                    "toggleable" => $col->isHidden() ? false : true,
+                    "has_hidden_if" => $col->getHiddenIf() !== null
                 ];
             }
         }


### PR DESCRIPTION
- When adding optional columns via widgetModifyingBehaviour, configured hidden_ifs were not applied and the columns were always shown in the configurator. 
- In the configurator, the initial toggleability is set via PHP according to server side visibility. We need to evaluate this at runtime here, in order to make the columns toggleable or not.
- Desired behaviour: if col is hidden (hidden_if evaluates to true), don't show it in configurator, otherwise do set it as toggleable