### PR TITLE
FIX DataTable: optional cols sometimes caused JS errors

### DIFF
--- a/Facades/Elements/UI5DataTable.php
+++ b/Facades/Elements/UI5DataTable.php
@@ -78,9 +78,14 @@ class UI5DataTable extends UI5AbstractElement implements UI5DataElementInterface
             $colsOptionalInitJs = '';
             if (! empty($colsOptional)) {
                 foreach ($colsOptional as $col) {
+                    $colEl = $this->getFacade()->getElement($col);
                     $colsOptionalInitJs .= <<<JS
                 
-                        oColsOptional['{$col->getDataColumnName()}'] = {$this->getFacade()->getElement($col)->buildJsConstructor()};
+                        var oCol = sap.ui.getCore().byId({$this->escapeString($colEl->getId())});
+                        if (! oCol) {
+                            oCol = {$colEl->buildJsConstructor()};
+                        }
+                        oColsOptional['{$col->getDataColumnName()}'] = oCol;
 JS;
                 }
             }


### PR DESCRIPTION
sometimes, when closing and re-opening lookup dialogues (responsive table), the optional cols caused duplicate ID JS errors, and caused the lookup dialogue to not re-open. Now added a check if ID exists already 