### PR TITLE
NEW Wizard: make step buttons always show above content

### DIFF
--- a/Facades/Elements/UI5WizardStep.php
+++ b/Facades/Elements/UI5WizardStep.php
@@ -84,7 +84,7 @@ JS;
         content: [
             {$introText}
             {$this->buildJsLayoutConstructor()},
-            {$this->getFacade()->getElement($toolbar)->buildJsConstructor()}.setStyle('Clear')
+            {$this->getFacade()->getElement($toolbar)->buildJsConstructor()}.setStyle('Clear').addStyleClass('exf-wizard-step-toolbar-sticky')
         ]
     }).addStyleClass('{$cssClasses}')
 JS;

--- a/Facades/js/openui5.template.css
+++ b/Facades/js/openui5.template.css
@@ -348,6 +348,7 @@ html.sap-tablet .sapMDialog, html.sap-desktop .sapMDialog {min-width: 25rem !imp
 .exf-wizard-step-hide-caption > .sapMWizardStepTitle {visibility: hidden; height: 0px; margin: 0;}
 /* FIX next-button of mobile wizzards floating in the upper part of the screen - even if the wizard itself is not visible! */
 html.sap-phone .sapMWizard .sapMWizardNextButtonVisible {position: relative !important; left: inherit !important; bottom: inherit !important;}
+.exf-wizard-step-toolbar-sticky {height: 3rem !important; position: sticky; bottom: 0; z-index: 1; margin: 0 0.5rem; background: var(--sapGroup_ContentBackground, #fff); border-radius: var(--sapElement_BorderCornerRadius, 0.5rem); box-shadow: var(--sapContent_Shadow2, 0 0.25rem 1rem rgba(0,0,0,.15));}
 
 /* Map */
 .exf-map {z-index: 0}


### PR DESCRIPTION
make the toolbar styled more natively (like the default next/previous buttons in ui5 wizards) as an overlay, so theyre always visible even if content is scrollable. Otherwise you always have to scroll to the bottom of the dialogue before being able to use them